### PR TITLE
add module in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
 	"version": "2.6.1",
 	"description": "Lightweight image and video viewer, supports youtube / vimeo",
 	"main": "index.js",
+	"module": "src/BigPicture.js",
 	"scripts": {
 		"build": "rollup -c",
 		"start": "run-p serve autobuild",


### PR DESCRIPTION
Module aware bundlers will use the more modern & performant code while legacy bundlers will keep working as usual with the compiled code.