### PR TITLE
Update npm-run-all to npm-run-all2

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
 	"devDependencies": {
 		"@rollup/plugin-buble": "^0.21.3",
 		"live-server": "^1.2.1",
-		"npm-run-all": "^4.1.5",
+		"npm-run-all2": "^7.0.2",
 		"rollup": "^1.10.1",
 		"rollup-plugin-size": "^0.2.0",
 		"rollup-plugin-terser": "^4.0.4"


### PR DESCRIPTION
Howdy! I was just poking around looking for a lightbox component for my blog and was checking out bigpicture. Looks great! Going to give it a whirl today!

I noticed you were running the unmaintained npm-run-all and wanted to offer up npm-run-all2, my community fork that I've been maintaining the last couple of years. It cleans up some of the older uneeded dependencies, and also cleans up a lot of the installation warnings the original version has. 

And of course if this is totally unwanted, feel free to close it up!

Looking forward to playing with bigpicture some more!